### PR TITLE
Fix: Coverage instrumentation

### DIFF
--- a/js/debug.js
+++ b/js/debug.js
@@ -32,7 +32,8 @@ const rootWallet = new ethers.Wallet(privKey, rootProvider);
     const artifact = require('./../build/contracts/Bridge.json');
     let bytecode = artifact.bytecode;
 
-    const meta = 'a265627a7a72305820';
+    // Disable stripping of bytecode, this breaks coverage instrumentation
+    /*const meta = 'a265627a7a72305820';
     const tmp = bytecode.indexOf(meta);
     if (tmp !== -1) {
       bytecode = bytecode.substring(0, tmp);
@@ -48,7 +49,7 @@ const rootWallet = new ethers.Wallet(privKey, rootProvider);
         break;
       }
       bytecode = n;
-    }
+    }*/
     _factory = new ethers.ContractFactory(
       artifact.abi,
       bytecode,


### PR DESCRIPTION
In `js/debug.js` we strip metadata of the contract and therefore the
bytecode differs from what we have inside `build/contracts`.
This breaks instrumentation.

fixes #8 