### PR TITLE
List of changes:

### DIFF
--- a/.develatus-apparatus.js
+++ b/.develatus-apparatus.js
@@ -1,5 +1,5 @@
 module.exports = {
-  testCommand: 'RPC_PORT=8333 yarn mocha --timeout 900000 test/',
+  testCommand: 'RPC_PORT=8333 yarn mocha --exit --timeout 900000 test/',
   artifactsPath: 'build/contracts',
   proxyPort: 8333,
   rpcUrl: 'http://localhost:8222',

--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -7,7 +7,7 @@ import './Verifier.sol';
 contract Bridge is Replayer, Verifier {
   uint16 public constant version = 1;
   uint256 public constant MAX_BLOCK_SIZE = 8096;
-  uint256 public constant MAX_SOLUTION_SIZE = 8096;
+  uint256 public constant MAX_SOLUTION_SIZE = 2048;
   // 1 ether
   uint256 public constant BOND_AMOUNT = 1000000000000000000;
   // >~14 minutes | in Blocks
@@ -449,7 +449,7 @@ contract Bridge is Replayer, Verifier {
     assembly {
       let size := sub(calldatasize, 100)
       // MAX_SOLUTION_SIZE
-      if gt(size, 8096) {
+      if gt(size, 2048) {
         revert(0, 0)
       }
       calldatacopy(0x80, 100, size)

--- a/contracts/InventoryStorage.sol
+++ b/contracts/InventoryStorage.sol
@@ -6,9 +6,7 @@ contract InventoryStorage {
     uint ok = 1;
 
     assembly {
-      let size := 0x800
-
-      for { let i := 0x80 } lt(i, size) { i := add(i, 0x40) } {
+      for { let i := 0x80 } lt(i, 0x880) { i := add(i, 0x40) } {
 
         let t := mload(i)
 
@@ -37,9 +35,7 @@ contract InventoryStorage {
 
   function _setStorage (bytes32 target, uint256 value) internal {
     assembly {
-      let size := 0x800
-
-      for { let i := 0x80 } lt(i, size) { i := add(i, 0x40) } {
+      for { let i := 0x80 } lt(i, 0x880) { i := add(i, 0x40) } {
         let t := mload(i)
 
         if eq(target, t) {
@@ -60,9 +56,7 @@ contract InventoryStorage {
 
   function _incrementStorage (bytes32 target, uint256 value) internal {
     assembly {
-      let size := 0x800
-
-      for { let i := 0x80 } lt(i, size) { i := add(i, 0x40) } {
+      for { let i := 0x80 } lt(i, 0x880) { i := add(i, 0x40) } {
         let t := mload(i)
 
         if eq(target, t) {
@@ -107,6 +101,8 @@ contract InventoryStorage {
     assembly {
       mstore(0, or(shl(64, target), shl(224, 0x0003)))
       mstore(24, shl(96, owner))
+      // we overwrite parts of the freeMemPtr, but this is not a problem because the
+      // memPtr would never be that high and we overwrite only 12 bytes :)
       mstore(44, shl(96, spender))
       ret := keccak256(0, 64)
     }

--- a/contracts/NutBerryRuntime.sol
+++ b/contracts/NutBerryRuntime.sol
@@ -106,7 +106,7 @@ contract NutBerryRuntime is EVMRuntime, Inventory {
     return '';
   }
 
-  // does need to handle storage lookups
+  // does need to handle storage lookups for the verification game
   function handleSLOAD(EVM memory state) internal {
     uint key = stackPop(state);
     uint res;
@@ -118,12 +118,10 @@ contract NutBerryRuntime is EVMRuntime, Inventory {
     stackPush(state, res);
   }
 
+  // this is also used just in the verification game at the moment,
+  // don't store it :)
   function handleSSTORE(EVM memory state) internal {
     uint key = stackPop(state);
     uint val = stackPop(state);
-
-    assembly {
-      sstore(key, val)
-    }
   }
 }

--- a/js/debug.js
+++ b/js/debug.js
@@ -32,8 +32,7 @@ const rootWallet = new ethers.Wallet(privKey, rootProvider);
     const artifact = require('./../build/contracts/Bridge.json');
     let bytecode = artifact.bytecode;
 
-    // Disable stripping of bytecode, this breaks coverage instrumentation
-    /*const meta = 'a265627a7a72305820';
+    const meta = 'a265627a7a72305820';
     const tmp = bytecode.indexOf(meta);
     if (tmp !== -1) {
       bytecode = bytecode.substring(0, tmp);
@@ -49,7 +48,8 @@ const rootWallet = new ethers.Wallet(privKey, rootProvider);
         break;
       }
       bytecode = n;
-    }*/
+    }
+
     _factory = new ethers.ContractFactory(
       artifact.abi,
       bytecode,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "rustbn.js": "=0.2.0"
   },
   "devDependencies": {
-    "develatus-apparatus": "https://github.com/pinkiebell/develatus-apparatus.git#0.1.1",
+    "develatus-apparatus": "https://github.com/pinkiebell/develatus-apparatus.git#v0.1.2",
     "eslint": "=6.0.1",
     "mocha": "=6.1.4",
     "solc": "=0.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NutBerry",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "NutBerry",
   "license": "MPL-2.0",
   "bin": {
@@ -11,7 +11,7 @@
     "lint": "eslint scripts/ js/ test/ evm/utils evm/test && solhint contracts/**/*{.sol,.slb}",
     "compile": "scripts/compile.js",
     "geth": "RPC_PORT=8222 scripts/geth.js",
-    "test": "yarn compile && yarn geth && RPC_PORT=8222 mocha --timeout=900000 test/",
+    "test": "yarn compile && yarn geth && RPC_PORT=8222 mocha --exit --timeout=900000 test/",
     "coverage": "yarn compile && yarn geth && develatus-apparatus"
   },
   "dependencies": {

--- a/test/Bridge.js
+++ b/test/Bridge.js
@@ -364,11 +364,4 @@ describe('Bridge/RPC', async function () {
       tx = await tx.wait();
     });
   });
-
-  describe('done', () => {
-    it('done', () => {
-      // TODO: leaks, it does not exit without this..
-      process.exit(0);
-    });
-  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -354,9 +354,9 @@ define-properties@^1.1.2:
   dependencies:
     object-keys "^1.0.12"
 
-"develatus-apparatus@https://github.com/pinkiebell/develatus-apparatus.git#0.1.1":
-  version "0.1.1"
-  resolved "https://github.com/pinkiebell/develatus-apparatus.git#cf53fe7dbc7d98c6bae8225f32ddf11809053685"
+"develatus-apparatus@https://github.com/pinkiebell/develatus-apparatus.git#v0.1.2":
+  version "0.1.2"
+  resolved "https://github.com/pinkiebell/develatus-apparatus.git#69af2126eb6fa67068c04d315ae8d66d03c2d55b"
 
 diff@3.5.0:
   version "3.5.0"


### PR DESCRIPTION
- tests: use mocha --exit
- Partial revert: Coverage instrumentation (#9)
  This solved coverage but broke the contract.
  We still need to change the bytecode to replace the `DEFAULT_CONTRACT`
  address.
- SECURITY: handleSSTORE; do not save storage slot; it's only used for the verifier part that should not modify storageg
- Fix MAX_SOLUTION_SIZE